### PR TITLE
Stop using Boost's tr1 regex implementation

### DIFF
--- a/src/DAEHandler.cpp
+++ b/src/DAEHandler.cpp
@@ -8,7 +8,7 @@
 #include <limits>
 #include <map>
 #include <unordered_map>
-#include <regex>
+#include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -694,8 +694,8 @@ void DAEHandler::process_glowpoints_properties(pcs_glow_array &glowbank) {
 }
 
 string strip_texture(string name) {
-	std::regex re("([^/\\\\]+?)(?:\\.[^./\\\\]+)?$");
-	return std::regex_replace(name, re, "$1", std::regex_constants::format_no_copy | std::regex_constants::format_first_only);
+	boost::regex re("([^/\\\\]+?)(?:\\.[^./\\\\]+)?$");
+	return boost::regex_replace(name, re, "$1", boost::regex_constants::format_no_copy | boost::regex_constants::format_first_only);
 
 }
 

--- a/src/DAEHandler.cpp
+++ b/src/DAEHandler.cpp
@@ -8,7 +8,7 @@
 #include <limits>
 #include <map>
 #include <unordered_map>
-#include <boost/tr1/regex.hpp>
+#include <regex>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -694,8 +694,8 @@ void DAEHandler::process_glowpoints_properties(pcs_glow_array &glowbank) {
 }
 
 string strip_texture(string name) {
-	std::tr1::regex re("([^/\\\\]+?)(?:\\.[^./\\\\]+)?$");
-	return std::tr1::regex_replace(name, re, "$1", std::tr1::regex_constants::format_no_copy | std::tr1::regex_constants::format_first_only);
+	std::regex re("([^/\\\\]+?)(?:\\.[^./\\\\]+)?$");
+	return std::regex_replace(name, re, "$1", std::regex_constants::format_no_copy | std::regex_constants::format_first_only);
 
 }
 


### PR DESCRIPTION
tr1 is gone in the Boost 1.65 and later.  ̶A̶d̶j̶u̶s̶t̶ ̶t̶h̶e̶ ̶c̶o̶d̶e̶ ̶b̶y̶ ̶s̶w̶i̶t̶c̶h̶i̶n̶g̶ ̶t̶o̶ ̶C̶+̶+̶1̶1̶'̶s̶ ̶r̶e̶g̶e̶x̶ ̶h̶e̶a̶d̶e̶r̶ ̶i̶n̶s̶t̶e̶a̶d̶.̶ I hope it's right solution.