### PR TITLE
Fix for compilation issue on Linux

### DIFF
--- a/src/GLee.h
+++ b/src/GLee.h
@@ -62,6 +62,7 @@
 #else // GLX
 	#define __glext_h_  /* prevent glext.h from being included  */
 	#define __glxext_h_ /* prevent glxext.h from being included */
+	#define GL_GLEXT_PROTOTYPES
 	#define GLX_GLXEXT_PROTOTYPES
 	#include <GL/gl.h>
 	#include <GL/glx.h>


### PR DESCRIPTION
This fixes #18. I don't know if this is correct way, but it works. Maybe some recent changes in Mesa broke PCS compilation on Linux.