### PR TITLE
Update requirements and CMake for easier setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ include(cmake/util.cmake)
 set_policy(CMP0051 OLD)
 set_policy(CMP0053 NEW)
 set_policy(CMP0054 NEW)
+set_policy(CMP0074 NEW)
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/external/cmake-modules")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,7 +138,7 @@ if(WIN32)
 
 	set(Boost_USE_STATIC_RUNTIME    OFF)
 endif()
-find_package(Boost REQUIRED COMPONENTS system filesystem regex)
+find_package(Boost 1.72.0 REQUIRED COMPONENTS system filesystem regex)
 
 target_link_libraries(pcs2 PRIVATE ${Boost_LIBRARIES})
 target_include_directories(pcs2 PRIVATE ${Boost_INCLUDE_DIRS})
@@ -147,7 +147,7 @@ target_include_directories(pcs2 PRIVATE ${Boost_INCLUDE_DIRS})
 find_package(DevIL REQUIRED)
 
 target_link_libraries(pcs2 PRIVATE ${IL_LIBRARIES} ${ILU_LIBRARIES} ${ILUT_LIBRARIES})
-target_include_directories(pcs2 PRIVATE ${IL_INCLUDE_DIR})
+target_include_directories(pcs2 PRIVATE ${IL_INCLUDE_DIR}/..)
 target_compile_definitions(pcs2 PRIVATE ILUT_USE_OPENGL)
 
 if(WIN32)
@@ -155,7 +155,7 @@ else()
 	set(wxWidgets_USE_DEBUG TRUE)
 	set(wxWidgets_USE_UNICODE TRUE)
 endif()
-find_package(wxWidgets 3.0.2 REQUIRED COMPONENTS core base gl adv)
+find_package(wxWidgets 3.0.5 REQUIRED COMPONENTS core base gl adv)
 
 target_include_directories(pcs2 PRIVATE ${wxWidgets_INCLUDE_DIRS})
 target_link_libraries(pcs2 PRIVATE ${wxWidgets_LIBRARIES})

--- a/src/DAEHandler.cpp
+++ b/src/DAEHandler.cpp
@@ -8,7 +8,7 @@
 #include <limits>
 #include <map>
 #include <unordered_map>
-#include <boost/tr1/regex.hpp>
+#include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -694,8 +694,8 @@ void DAEHandler::process_glowpoints_properties(pcs_glow_array &glowbank) {
 }
 
 string strip_texture(string name) {
-	std::tr1::regex re("([^/\\\\]+?)(?:\\.[^./\\\\]+)?$");
-	return std::tr1::regex_replace(name, re, "$1", std::tr1::regex_constants::format_no_copy | std::tr1::regex_constants::format_first_only);
+	boost::regex re("([^/\\\\]+?)(?:\\.[^./\\\\]+)?$");
+	return boost::regex_replace(name, re, "$1", boost::regex_constants::format_no_copy | boost::regex_constants::format_first_only);
 
 }
 


### PR DESCRIPTION
This updates the required Boost version to 1.72.0 and wxWidgets to 3.0.5. I will also be updating the build instructions in the wiki with the required information to enable full CMake automated setup for building.